### PR TITLE
Resource group status

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,14 +100,14 @@ func Execute() {
 
 	switch strings.ToLower(os.Args[1]) {
 	case "subscription":
-		err := subscriptionCmd.Parse(os.Args[2:])
+		err = subscriptionCmd.Parse(os.Args[2:])
 		if err != nil {
 			displayErrorMessage("", subscriptionCmd)
 		}
 		err = displaySubscriptions()
 		break
 	case "collect":
-		err := collectCmd.Parse(os.Args[2:])
+		err = collectCmd.Parse(os.Args[2:])
 		if err != nil {
 			displayErrorMessage("", collectCmd)
 		}
@@ -115,7 +115,7 @@ func Execute() {
 		err = collectBillingData()
 		break
 	case "generate":
-		err := generateCmd.Parse(os.Args[2:])
+		err = generateCmd.Parse(os.Args[2:])
 		if err != nil {
 			displayErrorMessage("", generateCmd)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -260,7 +260,7 @@ func getSubscriptionId() (string, error) {
 	selectedSub := ""
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Println("Please select on of the following subscription")
+	fmt.Println("Please select one of the following subscriptions")
 	for i, sub := range subscriptions {
 		fmt.Printf("%d: %s\n", i, sub.Name)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -171,7 +171,7 @@ func validateGenerateFlags(flags *flag.FlagSet) {
 
 	if !useStdOut && len(outputPath) == 0 {
 		displayErrorMessage("when not writing to stdout an output path must be specified", flags)
-	} else if formatLower == "excel" && len(outputPath) == 0 {
+	} else if formatLower == ExcelFormat && len(outputPath) == 0 {
 		displayErrorMessage("excel output cannot be written to stdout and so an output path must be specified", flags)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -352,6 +352,7 @@ func displayErrorMessage(msg string, flags *flag.FlagSet) {
 
 func processSubscriptionBillingPeriods(db *sqlite.CostManagementStore, billingDate time.Time) error {
 	svc := azure.NewCostService()
+	rgSvc := azure.NewResourceGroupService()
 	existingPeriods, err := db.GetSubscriptionBillingPeriods(subscriptionId)
 	if err != nil {
 		return err
@@ -364,6 +365,11 @@ func processSubscriptionBillingPeriods(db *sqlite.CostManagementStore, billingDa
 		return nil
 	}
 
+	rgs, err := rgSvc.ListResourceGroups(subscriptionId)
+	if err != nil {
+		return err
+	}
+
 	costs, err := svc.ResourceGroupCostsForPeriod(subscriptionId, billingDate.Year(), int(billingDate.Month()))
 	if err != nil {
 		return err
@@ -374,7 +380,7 @@ func processSubscriptionBillingPeriods(db *sqlite.CostManagementStore, billingDa
 		return err
 	}
 
-	err = db.SaveCosts(costs)
+	err = db.SaveCosts(costs, rgs)
 	if err != nil {
 		return err
 	}

--- a/internal/azure/groups.go
+++ b/internal/azure/groups.go
@@ -1,0 +1,85 @@
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/dazfuller/azcosts/internal/model"
+	"net/http"
+	"time"
+)
+
+type resourceGroupResponse struct {
+	Value []struct {
+		Id         string `json:"id"`
+		Location   string `json:"location"`
+		Name       string `json:"name"`
+		Properties struct {
+			ProvisioningState string `json:"provisioningState"`
+		} `json:"properties"`
+		Tags      map[string]string `json:"tags,omitempty"`
+		Type      string            `json:"type"`
+		ManagedBy string            `json:"managedBy,omitempty"`
+	} `json:"value"`
+}
+
+type ResourceGroupService struct {
+	azureService
+	apiVersion      string
+	endpoint        string
+	managementScope string
+}
+
+func NewResourceGroupService() ResourceGroupService {
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return ResourceGroupService{
+		azureService: azureService{
+			identity: cred,
+		},
+		apiVersion:      "2021-04-01",
+		endpoint:        "https://management.azure.com",
+		managementScope: "https://management.azure.com/.default",
+	}
+}
+
+func (rgs *ResourceGroupService) ListResourceGroups(subscriptionId string) ([]model.ResourceGroup, error) {
+	url := fmt.Sprintf("%s/subscriptions/%s/resourcegroups?api-version=%s", rgs.endpoint, subscriptionId, rgs.apiVersion)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := rgs.getAccessToken(rgs.apiVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	client := http.Client{Timeout: time.Second * 10}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var resGroupResp resourceGroupResponse
+	err = json.NewDecoder(resp.Body).Decode(&resGroupResp)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceGroups := make([]model.ResourceGroup, len(resGroupResp.Value))
+	for i, rg := range resGroupResp.Value {
+		resourceGroups[i] = model.ResourceGroup{
+			Id:       rg.Id,
+			Name:     rg.Name,
+			Location: rg.Location,
+		}
+	}
+
+	return resourceGroups, nil
+}

--- a/internal/azure/groups.go
+++ b/internal/azure/groups.go
@@ -53,7 +53,7 @@ func (rgs *ResourceGroupService) ListResourceGroups(subscriptionId string) ([]mo
 		return nil, err
 	}
 
-	token, err := rgs.getAccessToken(rgs.apiVersion)
+	token, err := rgs.getAccessToken(rgs.managementScope)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/formats/csv.go
+++ b/internal/formats/csv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/dazfuller/azcosts/internal/model"
 	"os"
+	"strconv"
 )
 
 type CsvFormatter struct {
@@ -34,7 +35,7 @@ func (cf CsvFormatter) Generate(costs []model.ResourceGroupSummary) error {
 	}
 
 	// Write header
-	header := []string{"Name", "Subscription Name", "Status"}
+	header := []string{"Name", "Subscription Name", "Active"}
 	for _, cost := range costs[0].Costs {
 		header = append(header, cost.Period)
 	}
@@ -45,7 +46,7 @@ func (cf CsvFormatter) Generate(costs []model.ResourceGroupSummary) error {
 	}
 
 	for _, rg := range costs {
-		record := []string{rg.Name, rg.SubscriptionName, rg.Status}
+		record := []string{rg.Name, rg.SubscriptionName, strconv.FormatBool(rg.Active)}
 		for _, cost := range rg.Costs {
 			record = append(record, fmt.Sprintf("%.2f", cost.Total))
 		}

--- a/internal/formats/csv.go
+++ b/internal/formats/csv.go
@@ -34,7 +34,7 @@ func (cf CsvFormatter) Generate(costs []model.ResourceGroupSummary) error {
 	}
 
 	// Write header
-	header := []string{"Name", "Subscription Name"}
+	header := []string{"Name", "Subscription Name", "Status"}
 	for _, cost := range costs[0].Costs {
 		header = append(header, cost.Period)
 	}
@@ -45,7 +45,7 @@ func (cf CsvFormatter) Generate(costs []model.ResourceGroupSummary) error {
 	}
 
 	for _, rg := range costs {
-		record := []string{rg.Name, rg.SubscriptionName}
+		record := []string{rg.Name, rg.SubscriptionName, rg.Status}
 		for _, cost := range rg.Costs {
 			record = append(record, fmt.Sprintf("%.2f", cost.Total))
 		}

--- a/internal/formats/excel.go
+++ b/internal/formats/excel.go
@@ -73,7 +73,7 @@ func (ef ExcelFormatter) addHeaders(f *excelize.File, sheetName string, costEntr
 	headers := []string{
 		"Resource Group",
 		"Subscription",
-		"Status",
+		"Active",
 	}
 
 	for _, bp := range costEntry.Costs {
@@ -96,7 +96,7 @@ func (ef ExcelFormatter) addCostDataToSheet(f *excelize.File, sheetName string, 
 		row := []interface{}{
 			entry.Name,
 			entry.SubscriptionName,
-			entry.Status,
+			entry.Active,
 		}
 
 		for _, cost := range entry.Costs {

--- a/internal/formats/excel.go
+++ b/internal/formats/excel.go
@@ -73,6 +73,7 @@ func (ef ExcelFormatter) addHeaders(f *excelize.File, sheetName string, costEntr
 	headers := []string{
 		"Resource Group",
 		"Subscription",
+		"Status",
 	}
 
 	for _, bp := range costEntry.Costs {
@@ -95,6 +96,7 @@ func (ef ExcelFormatter) addCostDataToSheet(f *excelize.File, sheetName string, 
 		row := []interface{}{
 			entry.Name,
 			entry.SubscriptionName,
+			entry.Status,
 		}
 
 		for _, cost := range entry.Costs {
@@ -122,7 +124,7 @@ func (ef ExcelFormatter) setSheetFormats(f *excelize.File, sheetName string, col
 
 	for i := range cols {
 		colName, _ := excelize.ColumnNumberToName(i + 1)
-		if i < 2 {
+		if i < 3 {
 			maxLength := 0
 			for _, v := range cols[i] {
 				if len(v) > maxLength {

--- a/internal/formats/text.go
+++ b/internal/formats/text.go
@@ -34,15 +34,15 @@ func (tf TextFormatter) Generate(costs []model.ResourceGroupSummary) error {
 		writer = bufio.NewWriter(file)
 	}
 
-	writer.WriteString(fmt.Sprintf("%-70s %-30s", "Resource Group", "Subscription"))
+	writer.WriteString(fmt.Sprintf("%-70s %-30s %-8s", "Resource Group", "Subscription", "Status"))
 
 	for _, bp := range costs[0].Costs {
 		writer.WriteString(fmt.Sprintf(" %12s", bp.Period))
 	}
 
-	writer.WriteString(fmt.Sprintf("%12s\n", "Total Costs"))
+	writer.WriteString(fmt.Sprintf(" %12s\n", "Total Costs"))
 
-	writer.WriteString(fmt.Sprintf("%-70s %-30s", strings.Repeat("=", 70), strings.Repeat("=", 30)))
+	writer.WriteString(fmt.Sprintf("%-70s %-30s %-8s", strings.Repeat("=", 70), strings.Repeat("=", 30), strings.Repeat("=", 8)))
 
 	for range costs[0].Costs {
 		writer.WriteString(fmt.Sprintf(" %12s", strings.Repeat("=", 12)))
@@ -51,7 +51,7 @@ func (tf TextFormatter) Generate(costs []model.ResourceGroupSummary) error {
 	writer.WriteString(fmt.Sprintf(" %12s\n", strings.Repeat("=", 12)))
 
 	for _, rg := range costs {
-		writer.WriteString(fmt.Sprintf("%-70s %-30s", trimValue(rg.Name, 50), trimValue(rg.SubscriptionName, 30)))
+		writer.WriteString(fmt.Sprintf("%-70s %-30s %-8s", trimValue(rg.Name, 50), trimValue(rg.SubscriptionName, 30), rg.Status))
 		for _, cost := range rg.Costs {
 			writer.WriteString(fmt.Sprintf(" %12.2f", cost.Total))
 		}

--- a/internal/formats/text.go
+++ b/internal/formats/text.go
@@ -34,7 +34,7 @@ func (tf TextFormatter) Generate(costs []model.ResourceGroupSummary) error {
 		writer = bufio.NewWriter(file)
 	}
 
-	writer.WriteString(fmt.Sprintf("%-70s %-30s %-8s", "Resource Group", "Subscription", "Status"))
+	writer.WriteString(fmt.Sprintf("%-70s %-30s %-7s", "Resource Group", "Subscription", "Active"))
 
 	for _, bp := range costs[0].Costs {
 		writer.WriteString(fmt.Sprintf(" %12s", bp.Period))
@@ -42,7 +42,7 @@ func (tf TextFormatter) Generate(costs []model.ResourceGroupSummary) error {
 
 	writer.WriteString(fmt.Sprintf(" %12s\n", "Total Costs"))
 
-	writer.WriteString(fmt.Sprintf("%-70s %-30s %-8s", strings.Repeat("=", 70), strings.Repeat("=", 30), strings.Repeat("=", 8)))
+	writer.WriteString(fmt.Sprintf("%-70s %-30s %-7s", strings.Repeat("=", 70), strings.Repeat("=", 30), strings.Repeat("=", 7)))
 
 	for range costs[0].Costs {
 		writer.WriteString(fmt.Sprintf(" %12s", strings.Repeat("=", 12)))
@@ -51,7 +51,7 @@ func (tf TextFormatter) Generate(costs []model.ResourceGroupSummary) error {
 	writer.WriteString(fmt.Sprintf(" %12s\n", strings.Repeat("=", 12)))
 
 	for _, rg := range costs {
-		writer.WriteString(fmt.Sprintf("%-70s %-30s %-8s", trimValue(rg.Name, 50), trimValue(rg.SubscriptionName, 30), rg.Status))
+		writer.WriteString(fmt.Sprintf("%-70s %-30s %-7t", trimValue(rg.Name, 50), trimValue(rg.SubscriptionName, 30), rg.Active))
 		for _, cost := range rg.Costs {
 			writer.WriteString(fmt.Sprintf(" %12.2f", cost.Total))
 		}

--- a/internal/model/groupbillingsummary.go
+++ b/internal/model/groupbillingsummary.go
@@ -8,6 +8,7 @@ type BillingPeriodCost struct {
 type ResourceGroupSummary struct {
 	Name             string              `json:"name"`
 	SubscriptionName string              `json:"subscriptionName"`
+	Status           string              `json:"status"`
 	Costs            []BillingPeriodCost `json:"costs"`
 	TotalCost        float64             `json:"totalCost"`
 }

--- a/internal/model/groupbillingsummary.go
+++ b/internal/model/groupbillingsummary.go
@@ -8,7 +8,7 @@ type BillingPeriodCost struct {
 type ResourceGroupSummary struct {
 	Name             string              `json:"name"`
 	SubscriptionName string              `json:"subscriptionName"`
-	Status           string              `json:"status"`
+	Active           bool                `json:"active"`
 	Costs            []BillingPeriodCost `json:"costs"`
 	TotalCost        float64             `json:"totalCost"`
 }

--- a/internal/model/resourcegroup.go
+++ b/internal/model/resourcegroup.go
@@ -1,0 +1,7 @@
+package model
+
+type ResourceGroup struct {
+	Id       string
+	Name     string
+	Location string
+}

--- a/internal/sqlite/dataservice.go
+++ b/internal/sqlite/dataservice.go
@@ -7,33 +7,73 @@ import (
 	"github.com/dazfuller/azcosts/internal/model"
 	_ "github.com/mattn/go-sqlite3"
 	"os"
+	"slices"
 	"strings"
 )
+
+const dbVersion = 1
 
 type CostManagementStore struct {
 	dbPath string
 	db     *sql.DB
 }
 
+func getDatabaseVersion(db *sql.DB) (int, error) {
+	row := db.QueryRow("PRAGMA user_version")
+
+	var userVersion int
+	err := row.Scan(&userVersion)
+	if err != nil {
+		return 0, err
+	}
+
+	return userVersion, nil
+}
+
+func updateDbVersion1(db *sql.DB) error {
+	_, err := db.Exec(`ALTER TABLE costs ADD resource_group_status TEXT DEFAULT 'inactive';
+
+	PRAGMA user_version = 1;`)
+
+	return err
+}
+
 // initializeDatabase initializes the database by creating the "costs" table if it doesn't exist.
 //
 // If an error occurs during table creation, the error is returned.
 func initializeDatabase(db *sql.DB) error {
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS costs
+	ver, err := getDatabaseVersion(db)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS costs
     (
         id INTEGER PRIMARY KEY AUTOINCREMENT
         , billing_from DATETIME
         , billing_period TEXT
         , resource_group TEXT
+        , resource_group_status TEXT
         , subscription_name TEXT
         , subscription_id TEXT
         , cost READ
         , cost_usd REAL
         , currency TEXT
-    )`)
-
+    );`)
 	if err != nil {
 		return err
+	}
+
+	_, err = db.Exec(fmt.Sprintf("PRAGMA user_version = %d", dbVersion))
+	if err != nil {
+		return err
+	}
+
+	if ver < dbVersion {
+		err = updateDbVersion1(db)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -76,7 +116,7 @@ func (cm *CostManagementStore) Close() error {
 	return nil
 }
 
-func (cm *CostManagementStore) SaveCosts(costs []model.ResourceGroupCost) error {
+func (cm *CostManagementStore) SaveCosts(costs []model.ResourceGroupCost, currentResourceGroups []model.ResourceGroup) error {
 	tx, err := cm.db.Begin()
 	if err != nil {
 		return err
@@ -87,6 +127,7 @@ func (cm *CostManagementStore) SaveCosts(costs []model.ResourceGroupCost) error 
 			billing_from
 			, billing_period
 			, resource_group
+			, resource_group_status
 			, subscription_name
 			, subscription_id
 			, cost
@@ -95,7 +136,7 @@ func (cm *CostManagementStore) SaveCosts(costs []model.ResourceGroupCost) error 
 		)
 		VALUES
 		(
-			?, ?, ?, ?, ?, ?, ?, ?)
+			?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`)
 	if err != nil {
 		tx.Rollback()
@@ -103,7 +144,23 @@ func (cm *CostManagementStore) SaveCosts(costs []model.ResourceGroupCost) error 
 	}
 
 	for _, cost := range costs {
-		_, err := stmt.Exec(cost.BillingPeriod, cost.BillingPeriod.Format("2006-01"), cost.Name, cost.SubscriptionName, cost.SubscriptionId, cost.Cost, cost.CostUSD, cost.Currency)
+		status := "inactive"
+		if slices.ContainsFunc(currentResourceGroups, func(rg model.ResourceGroup) bool {
+			return cost.Name == rg.Name
+		}) {
+			status = "active"
+		}
+
+		_, err := stmt.Exec(
+			cost.BillingPeriod,
+			cost.BillingPeriod.Format("2006-01"),
+			cost.Name,
+			status,
+			cost.SubscriptionName,
+			cost.SubscriptionId,
+			cost.Cost,
+			cost.CostUSD,
+			cost.Currency)
 		if err != nil {
 			tx.Rollback()
 			return err
@@ -124,14 +181,18 @@ func (cm *CostManagementStore) createSummaryView(billingPeriods []string) error 
 	queryBuilder := strings.Builder{}
 	queryBuilder.WriteString("DROP VIEW IF EXISTS vw_cost_summary;")
 	queryBuilder.WriteString("CREATE VIEW vw_cost_summary AS\n")
-	queryBuilder.WriteString("SELECT resource_group AS `ResourceGroup`, subscription_name AS `Subscription`\n")
+	queryBuilder.WriteString("SELECT resource_group AS `ResourceGroup`, subscription_name AS `Subscription`, current_status AS `Status`\n")
 
 	for _, bp := range billingPeriods {
 		queryBuilder.WriteString(fmt.Sprintf(", SUM(cost) filter (where billing_period = '%[1]s') AS `%[1]s`\n", bp))
 	}
 
 	queryBuilder.WriteString(", SUM(cost) AS `TotalCost`\n")
-	queryBuilder.WriteString("FROM costs\n")
+	queryBuilder.WriteString("FROM (\n")
+	queryBuilder.WriteString("    SELECT resource_group, subscription_id, subscription_name, resource_group_status, cost, billing_period\n")
+	queryBuilder.WriteString("           , LAST_VALUE(resource_group_status) OVER (PARTITION BY subscription_id, resource_group ORDER BY billing_from RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS `current_status`\n")
+	queryBuilder.WriteString("    FROM costs\n")
+	queryBuilder.WriteString(")\n")
 	queryBuilder.WriteString("GROUP BY resource_group, subscription_name;\n")
 
 	_, err := cm.db.Exec(queryBuilder.String())
@@ -164,7 +225,7 @@ func (cm *CostManagementStore) GenerateSummaryByResourceGroup() ([]model.Resourc
 	for rows.Next() {
 		_ = rows.Scan(rowPtr...)
 		groupBillingCosts := make([]model.BillingPeriodCost, 0, len(billingPeriods))
-		for i := 2; i < len(row)-1; i++ {
+		for i := 3; i < len(row)-1; i++ {
 			groupBillingCosts = append(groupBillingCosts, model.BillingPeriodCost{
 				Period: cols[i],
 				Total:  costToFloat(row[i]),
@@ -174,6 +235,7 @@ func (cm *CostManagementStore) GenerateSummaryByResourceGroup() ([]model.Resourc
 		summary = append(summary, model.ResourceGroupSummary{
 			Name:             row[0].(string),
 			SubscriptionName: row[1].(string),
+			Status:           row[2].(string),
 			Costs:            groupBillingCosts,
 			TotalCost:        costToFloat(row[len(row)-1]),
 		})


### PR DESCRIPTION
This release introduces a new feature whereby the status of the resource group returned from the billing information is also persisted with the data, and then later surfaced back through the reports. This allows users to see if a resource group has been deleted and will therefore no longer be incurring costs.

There were a few minor bugs fixed as well such as typos, and one instance where the `err` variable was being shadowed inside of a scope, preventing the error from bubbling up